### PR TITLE
ignore inline scripts that dont have a src

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = function (options) {
 
     function addDependency (dep) {
       debug('+ %s (%s)', dep.path, dep.type)
+      if (!dep.path) return
       let abs = path.resolve(file.dirname, dep.path)
       let depFile = tree.findFile(abs)
       if (!depFile) depFile = tree.addFile(abs)

--- a/test/fixtures/inline-script/index.html
+++ b/test/fixtures/inline-script/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Hello World</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.css">
+  </head>
+  <body>
+    <script type="state">{"server":"state"}</script>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,17 @@ describe('html plugin', function () {
     })
   })
 
+  it('should ignore scripts without a source', function () {
+    let runner = mako({ root: fixture('inline-script') }).use(html())
+    let entry = runner.tree.addFile(fixture('inline-script/index.html'))
+    entry.contents = fs.readFileSync(entry.path)
+
+    return runner.build(entry).then(function (build) {
+      let file = build.tree.findFile(entry.path)
+      assert.lengthOf(file.dependencies(), 0)
+    })
+  })
+
   it('should only add dependencies once', function () {
     let runner = mako({ root: fixture('duplicate') }).use(html())
     let entry = runner.tree.addFile(fixture('duplicate/index.html'))


### PR DESCRIPTION
This PR allows for HTML pages that contain template data. Something like this:

```js
<script type="state">{"server":"state"}</script>
```

Also, inline scripts in general. It'll just ignore these scripts.